### PR TITLE
Create Service layer for article

### DIFF
--- a/src/main/java/kr/kw/matcher/module/article/constant/SearchType.java
+++ b/src/main/java/kr/kw/matcher/module/article/constant/SearchType.java
@@ -1,0 +1,17 @@
+package kr.kw.matcher.module.article.constant;
+
+import lombok.Getter;
+
+public enum SearchType {
+    TITLE("제목"),
+    CONTENT("본문"),
+    ID("유저 ID")
+    ;
+
+    @Getter
+    private final String description;
+
+    SearchType(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/kr/kw/matcher/module/article/domain/Article.java
+++ b/src/main/java/kr/kw/matcher/module/article/domain/Article.java
@@ -7,6 +7,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 
 @Entity
@@ -38,6 +39,19 @@ public class Article {
     @Column(nullable = false)
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime createdDt; // 생성일시
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Article)) return false;
+        Article article = (Article) o;
+        return id != null && id.equals(article.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 
     public static Article of(String title, String content, User user) {
         return Article.builder()

--- a/src/main/java/kr/kw/matcher/module/article/domain/ArticleComment.java
+++ b/src/main/java/kr/kw/matcher/module/article/domain/ArticleComment.java
@@ -6,6 +6,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Setter
@@ -31,6 +32,19 @@ public class ArticleComment {
     @Column(nullable = false)
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime createdDt; // 생성일시
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ArticleComment)) return false;
+        ArticleComment that = (ArticleComment) o;
+        return id != null && id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 
     public static ArticleComment of(Article article, User user, String content) {
         return ArticleComment.builder()

--- a/src/main/java/kr/kw/matcher/module/article/dto/ArticleCommentDto.java
+++ b/src/main/java/kr/kw/matcher/module/article/dto/ArticleCommentDto.java
@@ -1,5 +1,9 @@
 package kr.kw.matcher.module.article.dto;
 
+import kr.kw.matcher.module.article.domain.Article;
+import kr.kw.matcher.module.article.domain.ArticleComment;
+import kr.kw.matcher.module.user.domain.User;
+import kr.kw.matcher.module.user.dto.UserDto;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -12,27 +16,45 @@ import java.time.LocalDateTime;
 public class ArticleCommentDto {
     Long id;
     Long articleId;
-    Long userId;
+    UserDto userDto;
     String content;
     LocalDateTime createdDt;
 
-    public static ArticleCommentDto of(Long articleId, Long userId, String content) {
+    public static ArticleCommentDto of(Long articleId, UserDto userDto, String content) {
         return ArticleCommentDto.builder()
                 .id(null)
                 .articleId(articleId)
-                .userId(userId)
+                .userDto(userDto)
                 .content(content)
                 .createdDt(null)
                 .build();
     }
 
-    public static ArticleCommentDto of(Long id, Long articleId, Long userId, String content, LocalDateTime createdDt) {
+    public static ArticleCommentDto of(Long id, Long articleId, UserDto userDto, String content, LocalDateTime createdDt) {
         return ArticleCommentDto.builder()
                 .id(id)
                 .articleId(articleId)
-                .userId(userId)
+                .userDto(userDto)
                 .content(content)
                 .createdDt(createdDt)
                 .build();
+    }
+
+    public static ArticleCommentDto from(ArticleComment entity) {
+        return ArticleCommentDto.builder()
+                .id(entity.getId())
+                .articleId(entity.getArticle().getId())
+                .userDto(UserDto.from(entity.getUser()))
+                .content(entity.getContent())
+                .createdDt(entity.getCreatedDt())
+                .build();
+    }
+
+    public ArticleComment toEntity(Article article, User user) {
+        return ArticleComment.of(
+                article,
+                user,
+                content
+        );
     }
 }

--- a/src/main/java/kr/kw/matcher/module/article/dto/ArticleDto.java
+++ b/src/main/java/kr/kw/matcher/module/article/dto/ArticleDto.java
@@ -1,5 +1,8 @@
 package kr.kw.matcher.module.article.dto;
 
+import kr.kw.matcher.module.article.domain.Article;
+import kr.kw.matcher.module.user.domain.User;
+import kr.kw.matcher.module.user.dto.UserDto;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -13,26 +16,49 @@ public class ArticleDto {
     Long id;
     String title;
     String content;
-    Long userId;
+    UserDto userDto;
     LocalDateTime createdDt;
 
-    public static ArticleDto of(String title, String content, Long userId) {
+    public static ArticleDto of(String title, String content, UserDto userDto) {
         return ArticleDto.builder()
                 .id(null)
                 .title(title)
                 .content(content)
-                .userId(userId)
+                .userDto(userDto)
                 .createdDt(null)
                 .build();
     }
 
-    public static ArticleDto of(Long id, String title, String content, Long userId, LocalDateTime createdDt) {
+    public static ArticleDto of(Long id, String title, String content, UserDto userDto, LocalDateTime createdDt) {
         return ArticleDto.builder()
                 .id(id)
                 .title(title)
                 .content(content)
-                .userId(userId)
+                .userDto(userDto)
                 .createdDt(createdDt)
                 .build();
+    }
+
+    // toEntity 를 static 으로 쓸 수 없어서 만든 팩토리 메소드
+    public static ArticleDto of(ArticleDto dto) {
+        return ArticleDto.builder()
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .userDto(dto.getUserDto())
+                .build();
+    }
+
+    public Article toEntity(User user) {
+        return Article.of(title, content, user);
+    }
+
+    public static ArticleDto from(Article entity) {
+        return ArticleDto.of(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getContent(),
+                UserDto.from(entity.getUser()),
+                entity.getCreatedDt()
+        );
     }
 }

--- a/src/main/java/kr/kw/matcher/module/article/dto/ArticleWithCommentsDto.java
+++ b/src/main/java/kr/kw/matcher/module/article/dto/ArticleWithCommentsDto.java
@@ -1,9 +1,13 @@
 package kr.kw.matcher.module.article.dto;
 
+import kr.kw.matcher.module.article.domain.Article;
+import kr.kw.matcher.module.user.dto.UserDto;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Setter
 @Getter
@@ -14,7 +18,7 @@ public class ArticleWithCommentsDto {
     Long id;
     String title;
     String content;
-    Long userId;
+    UserDto userDto;
     Set<ArticleCommentDto> articleCommentDtos;
     LocalDateTime createdDt;
 
@@ -22,7 +26,7 @@ public class ArticleWithCommentsDto {
             Long id,
             String title,
             String content,
-            Long userId,
+            UserDto userDto,
             Set<ArticleCommentDto> articleCommentDtos,
             LocalDateTime createdDt
     ) {
@@ -30,9 +34,22 @@ public class ArticleWithCommentsDto {
                 .id(id)
                 .title(title)
                 .content(content)
-                .userId(userId)
+                .userDto(userDto)
                 .articleCommentDtos(articleCommentDtos)
                 .createdDt(createdDt)
                 .build();
+    }
+
+    public static ArticleWithCommentsDto from(Article entity) {
+        return ArticleWithCommentsDto.of(
+                entity.getId(),
+                entity.getTitle(),
+                entity.getContent(),
+                UserDto.from(entity.getUser()),
+                entity.getArticleComments().stream()
+                        .map(ArticleCommentDto::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                entity.getCreatedDt()
+        );
     }
 }

--- a/src/main/java/kr/kw/matcher/module/article/repository/ArticleCommentRepository.java
+++ b/src/main/java/kr/kw/matcher/module/article/repository/ArticleCommentRepository.java
@@ -3,5 +3,10 @@ package kr.kw.matcher.module.article.repository;
 import kr.kw.matcher.module.article.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
+    List<ArticleComment> findByArticle_Id(Long articleId);
+
+    void deleteByIdAndUser_Id(Long articleCommentId, Long userId);
 }

--- a/src/main/java/kr/kw/matcher/module/article/repository/ArticleRepository.java
+++ b/src/main/java/kr/kw/matcher/module/article/repository/ArticleRepository.java
@@ -1,7 +1,32 @@
 package kr.kw.matcher.module.article.repository;
 
+import com.querydsl.core.types.dsl.StringExpression;
 import kr.kw.matcher.module.article.domain.Article;
+import kr.kw.matcher.module.article.domain.QArticle;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 
-public interface ArticleRepository extends JpaRepository<Article, Long> {
+public interface ArticleRepository extends
+        JpaRepository<Article, Long>,
+        QuerydslPredicateExecutor<Article>, // 모든 필드에 대한 검색 기능 추가
+        QuerydslBinderCustomizer<QArticle> // 추가적인 검색 기능을 위해 추가
+{
+    Page<Article> findByTitleContaining(String title, Pageable pageable);
+    Page<Article> findByContentContaining(String content, Pageable pageable);
+    Page<Article> findByUser_IdContaining(String userId, Pageable pageable);
+
+    void deleteByIdAndUser_Id(Long articleId, Long userId);
+
+    @Override
+    default void customize(QuerydslBindings bindings, QArticle root) {
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.title, root.content);
+
+        bindings.bind(root.title).first(StringExpression::containsIgnoreCase); // 부분 검색 가능, 대소문자 구분 X
+        bindings.bind(root.content).first(StringExpression::containsIgnoreCase);
+    }
 }

--- a/src/main/java/kr/kw/matcher/module/article/service/ArticleCommentService.java
+++ b/src/main/java/kr/kw/matcher/module/article/service/ArticleCommentService.java
@@ -1,0 +1,70 @@
+package kr.kw.matcher.module.article.service;
+
+import kr.kw.matcher.module.article.domain.Article;
+import kr.kw.matcher.module.article.domain.ArticleComment;
+import kr.kw.matcher.module.article.dto.ArticleCommentDto;
+import kr.kw.matcher.module.article.repository.ArticleCommentRepository;
+import kr.kw.matcher.module.article.repository.ArticleRepository;
+import kr.kw.matcher.module.user.domain.User;
+import kr.kw.matcher.module.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ArticleCommentService {
+    private final ArticleRepository articleRepository;
+    private final ArticleCommentRepository articleCommentRepository;
+    private final UserRepository userRepository;
+
+    // 특정 게시글의 댓글 조회
+    @Transactional(readOnly = true)
+    public List<ArticleCommentDto> searchArticleComments(Long articleId) {
+        return articleCommentRepository.findByArticle_Id(articleId)
+                .stream()
+                .map(ArticleCommentDto::from)
+                .collect(Collectors.toList());
+    }
+
+    // 댓글 저장
+    public void saveArticleComment(ArticleCommentDto dto) {
+        try {
+            Article article = articleRepository.getReferenceById(dto.getArticleId());
+            User user = userRepository.getReferenceById(dto.getUserDto().getId());
+
+            articleCommentRepository.save(dto.toEntity(article, user));
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 저장을 실패했습니다. 댓글 작성에 필요한 정보를 찾을 수 없습니다 - {}", e.getLocalizedMessage());
+        }
+    }
+
+    // 댓글 업데이트
+    public void updateArticleComment(Long articleCommentId, ArticleCommentDto dto) {
+        try {
+            ArticleComment articleComment = articleCommentRepository.getReferenceById(articleCommentId);
+            User user = userRepository.getReferenceById(dto.getUserDto().getId());
+
+            if (articleComment.getUser().equals(user)) {
+                if (dto.getContent() != null) {
+                    articleComment.setContent(dto.getContent());
+                }
+            }
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 업데이트를 실패했습니다. 댓글을 찾을 수 없습니다. - dto : {}", dto);
+        }
+    }
+
+    // 댓글 삭제
+    // TODO: soft delete 로 변경 예정
+    public void deleteArticleComment(Long articleCommentId, Long userId) {
+        articleCommentRepository.deleteByIdAndUser_Id(articleCommentId, userId);
+    }
+}

--- a/src/main/java/kr/kw/matcher/module/article/service/ArticleService.java
+++ b/src/main/java/kr/kw/matcher/module/article/service/ArticleService.java
@@ -1,0 +1,89 @@
+package kr.kw.matcher.module.article.service;
+
+import kr.kw.matcher.module.article.constant.SearchType;
+import kr.kw.matcher.module.article.domain.Article;
+import kr.kw.matcher.module.article.dto.ArticleDto;
+import kr.kw.matcher.module.article.dto.ArticleWithCommentsDto;
+import kr.kw.matcher.module.article.repository.ArticleRepository;
+import kr.kw.matcher.module.user.domain.User;
+import kr.kw.matcher.module.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ArticleService {
+    private final ArticleRepository articleRepository;
+    private final UserRepository userRepository;
+
+    // SearchType 에 따른 게시글 조회
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticles(SearchType searchType, String searchKeyword, Pageable pageable) {
+        if (searchKeyword == null || searchKeyword.isBlank()) { // 키워드 없이 검색된다면 전체 게시글 조회
+            return articleRepository.findAll(pageable).map(ArticleDto::from);
+        }
+
+        if (searchType == SearchType.TITLE) {
+            return articleRepository.findByTitleContaining(searchKeyword, pageable).map(ArticleDto::from);
+        }
+        else if (searchType == SearchType.CONTENT) {
+            return articleRepository.findByContentContaining(searchKeyword, pageable).map(ArticleDto::from);
+        }
+        else { // TODO: 작성자 아이디 or 작성자 닉네임으로 검색 고려하기
+            return articleRepository.findByUser_IdContaining(searchKeyword, pageable).map(ArticleDto::from);
+        }
+    }
+
+    // 특정 게시글 조회
+    @Transactional(readOnly = true)
+    public ArticleWithCommentsDto getArticleWithComments(Long articleId) {
+        return articleRepository.findById(articleId)
+                .map(ArticleWithCommentsDto::from)
+                .orElseThrow(() -> new EntityNotFoundException("게시글 조회를 실패했습니다. 게시글을 찾을 수 없습니다. - articleId : " + articleId));
+    }
+
+    // 게시글 저장
+    public void saveArticle(ArticleDto dto) {
+        User user = userRepository.getReferenceById(dto.getUserDto().getId());
+
+        ArticleDto save = ArticleDto.of(dto);
+        articleRepository.save(save.toEntity(user));
+    }
+
+    // 게시글 업데이트
+    public void updateArticle(Long articleId, ArticleDto dto) {
+        try {
+            Article article = articleRepository.getReferenceById(articleId);
+            User user = userRepository.getReferenceById(dto.getUserDto().getId());
+
+            if (article.getUser().equals(user)) { // 게시글 작성자 == 현재 로그인한 사용자
+                if (dto.getTitle() != null) {
+                    article.setTitle(dto.getTitle());
+                }
+                if (dto.getContent() != null) {
+                    article.setContent(dto.getContent());
+                }
+            }
+        } catch (EntityNotFoundException e) {
+            log.warn("게시글 업데이트를 실패했습니다. 게시글을 찾을 수 없습니다. - dto : {}", dto);
+        }
+    }
+
+    // 게시글 삭제
+    // TODO: soft delete 로 변경 예정
+    public void deleteArticle(Long articleId, Long userId) {
+        articleRepository.deleteByIdAndUser_Id(articleId, userId);
+    }
+
+    public long getArticleCount() {
+        return articleRepository.count();
+    }
+}

--- a/src/main/java/kr/kw/matcher/module/article/service/PaginationService.java
+++ b/src/main/java/kr/kw/matcher/module/article/service/PaginationService.java
@@ -1,0 +1,23 @@
+package kr.kw.matcher.module.article.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+public class PaginationService {
+    private static final int BAR_LENGTH = 5;
+
+    public List<Integer> getPaginationBarNumbers(int currentPageNumber, int totalPages) {
+        int startNumber = Math.max(currentPageNumber - (BAR_LENGTH / 2), 0);
+        int endNumber = Math.min(startNumber + BAR_LENGTH, totalPages);
+
+        return IntStream.range(startNumber, endNumber).boxed().collect(Collectors.toList());
+    }
+
+    public int currentBarLength() {
+        return BAR_LENGTH;
+    }
+}

--- a/src/main/java/kr/kw/matcher/module/user/domain/User.java
+++ b/src/main/java/kr/kw/matcher/module/user/domain/User.java
@@ -8,6 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Setter
@@ -32,6 +33,19 @@ public class User {
 
     @Column(nullable = false)
     private Boolean deleted;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof User)) return false;
+        User user = (User) o;
+        return id != null && id.equals(user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 
     public static User of(Long id) {
         return User.builder()

--- a/src/main/java/kr/kw/matcher/module/user/dto/UserDto.java
+++ b/src/main/java/kr/kw/matcher/module/user/dto/UserDto.java
@@ -1,0 +1,33 @@
+package kr.kw.matcher.module.user.dto;
+
+import kr.kw.matcher.module.user.domain.User;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDto {
+    Long id;
+    String nickname;
+    LocalDateTime createdDt;
+
+    public static UserDto of(Long id) {
+        return UserDto.builder()
+                .id(id)
+                .build();
+    }
+
+    public static UserDto from(User entity) {
+        return UserDto.builder()
+                .id(entity.getId())
+                .build();
+    }
+
+    public User toEntity() {
+        return User.of(id);
+    }
+}

--- a/src/test/java/kr/kw/matcher/module/article/service/ArticleCommentServiceTest.java
+++ b/src/test/java/kr/kw/matcher/module/article/service/ArticleCommentServiceTest.java
@@ -1,0 +1,181 @@
+package kr.kw.matcher.module.article.service;
+
+import kr.kw.matcher.module.article.domain.Article;
+import kr.kw.matcher.module.article.domain.ArticleComment;
+import kr.kw.matcher.module.article.dto.ArticleCommentDto;
+import kr.kw.matcher.module.article.repository.ArticleCommentRepository;
+import kr.kw.matcher.module.article.repository.ArticleRepository;
+import kr.kw.matcher.module.user.domain.User;
+import kr.kw.matcher.module.user.domain.UserRepository;
+import kr.kw.matcher.module.user.dto.UserDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비즈니스 로직 - 댓글")
+@ExtendWith(MockitoExtension.class)
+class ArticleCommentServiceTest {
+    @InjectMocks
+    private ArticleCommentService sut;
+
+    @Mock
+    private ArticleRepository articleRepository;
+    @Mock
+    private ArticleCommentRepository articleCommentRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @DisplayName("게시글 ID로 조회하면, 해당하는 댓글 리스트를 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingArticleComments_thenReturnsArticleComments() {
+        // Given
+        Long articleId = 1L;
+        ArticleComment expected = createArticleComment("content");
+        given(articleCommentRepository.findByArticle_Id(articleId)).willReturn(List.of(expected));
+
+        // When
+        List<ArticleCommentDto> actual = sut.searchArticleComments(articleId);
+
+        // Then
+        assertThat(actual)
+                .hasSize(1)
+                .first().hasFieldOrPropertyWithValue("content", expected.getContent());
+        then(articleCommentRepository).should().findByArticle_Id(articleId);
+    }
+
+    @DisplayName("댓글 정보를 입력하면, 댓글을 저장한다.")
+    @Test
+    void givenArticleCommentInfo_whenSavingArticleComment_thenSavesArticleComment() {
+        // Given
+        ArticleCommentDto dto = createArticleCommentDto("댓글");
+        given(articleRepository.getReferenceById(dto.getArticleId())).willReturn(createArticle());
+        given(userRepository.getReferenceById(dto.getUserDto().getId())).willReturn(createUser());
+        given(articleCommentRepository.save(any(ArticleComment.class))).willReturn(null);
+
+        // When
+        sut.saveArticleComment(dto);
+
+        // Then
+        then(articleRepository).should().getReferenceById(dto.getArticleId());
+        then(userRepository).should().getReferenceById(dto.getUserDto().getId());
+        then(articleCommentRepository).should().save(any(ArticleComment.class));
+    }
+
+    @DisplayName("댓글 저장을 시도했는데 맞는 게시글이 없으면, 경고 로그를 찍고 아무것도 안 한다.")
+    @Test
+    void givenNonexistentArticle_whenSavingArticleComment_thenLogsSituationAndDoesNothing() {
+        // Given
+        ArticleCommentDto dto = createArticleCommentDto("댓글");
+        given(articleRepository.getReferenceById(dto.getArticleId())).willThrow(EntityNotFoundException.class);
+
+        // When
+        sut.saveArticleComment(dto);
+
+        // Then
+        then(articleRepository).should().getReferenceById(dto.getArticleId());
+        then(userRepository).shouldHaveNoInteractions();
+        then(articleCommentRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("댓글 정보를 입력하면, 댓글을 수정한다.")
+    @Test
+    void givenArticleCommentInfo_whenUpdatingArticleComment_thenUpdatesArticleComment() { // TODO: 수정하기
+        // Given
+        String oldContent = "content";
+        String updatedContent = "댓글";
+        ArticleComment articleComment = createArticleComment(oldContent);
+        ArticleCommentDto dto = createArticleCommentDto(updatedContent);
+        given(articleCommentRepository.getReferenceById(dto.getId())).willReturn(articleComment);
+        given(userRepository.getReferenceById(dto.getUserDto().getId())).willReturn(dto.getUserDto().toEntity());
+
+        // When
+        sut.updateArticleComment(articleComment.getId(), dto);
+
+        // Then
+        assertThat(articleComment.getContent())
+                .isNotEqualTo(oldContent)
+                .isEqualTo(updatedContent);
+        then(articleCommentRepository).should().getReferenceById(dto.getId());
+        then(userRepository).should().getReferenceById(dto.getUserDto().getId());
+    }
+
+    @DisplayName("없는 댓글 정보를 수정하려고 하면, 경고 로그를 찍고 아무 것도 안 한다.")
+    @Test
+    void givenNonexistentArticleComment_whenUpdatingArticleComment_thenLogsWarningAndDoesNothing() { // TODO: 수정하기
+        // Given
+        ArticleCommentDto dto = createArticleCommentDto("댓글");
+        given(articleCommentRepository.getReferenceById(dto.getId())).willThrow(EntityNotFoundException.class);
+
+        // When
+        sut.updateArticleComment(dto.getId(), dto);
+
+        // Then
+        then(articleCommentRepository).should().getReferenceById(dto.getId());
+    }
+
+    @DisplayName("댓글 ID를 입력하면, 댓글을 삭제한다.")
+    @Test
+    void givenArticleCommentId_whenDeletingArticleComment_thenDeletesArticleComment() {
+        // Given
+        Long articleCommentId = 1L;
+        Long userId = 1L;
+        willDoNothing().given(articleCommentRepository).deleteByIdAndUser_Id(articleCommentId, userId);
+
+        // When
+        sut.deleteArticleComment(articleCommentId, userId);
+
+        // Then
+        then(articleCommentRepository).should().deleteByIdAndUser_Id(articleCommentId, userId);
+    }
+
+    private User createUser() {
+        return User.of(1L);
+    }
+
+    private UserDto createUserDto() {
+        return UserDto.of(1L);
+    }
+
+    private Article createArticle() {
+        Article article = Article.of(
+                "title",
+                "content",
+                createUser()
+        );
+        ReflectionTestUtils.setField(article, "id", 1L);
+
+        return article;
+    }
+
+    private ArticleComment createArticleComment(String content) {
+        ArticleComment articleComment = ArticleComment.of(
+                Article.of("title", "content", createUser()),
+                createUser(),
+                content
+        );
+        ReflectionTestUtils.setField(articleComment, "id", 1L);
+
+        return articleComment;
+    }
+
+    private ArticleCommentDto createArticleCommentDto(String content) {
+        return ArticleCommentDto.of(
+                1L,
+                1L,
+                createUserDto(),
+                content, LocalDateTime.now()
+        );
+    }
+}

--- a/src/test/java/kr/kw/matcher/module/article/service/ArticleServiceTest.java
+++ b/src/test/java/kr/kw/matcher/module/article/service/ArticleServiceTest.java
@@ -1,0 +1,212 @@
+package kr.kw.matcher.module.article.service;
+
+import kr.kw.matcher.module.article.constant.SearchType;
+import kr.kw.matcher.module.article.domain.Article;
+import kr.kw.matcher.module.article.dto.ArticleDto;
+import kr.kw.matcher.module.article.dto.ArticleWithCommentsDto;
+import kr.kw.matcher.module.article.repository.ArticleRepository;
+import kr.kw.matcher.module.user.domain.User;
+import kr.kw.matcher.module.user.domain.UserRepository;
+import kr.kw.matcher.module.user.dto.UserDto;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@Slf4j
+@DisplayName("비즈니스 로직 - 게시판")
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+    @InjectMocks private ArticleService sut;
+
+    @Mock private ArticleRepository articleRepository;
+    @Mock private UserRepository userRepository;
+
+    @DisplayName("검색어 없이 게시글을 검색하면, 게시판 페이지를 반환한다.")
+    @Test
+    void givenNoSearchParameters_whenSearchingArticles_thenReturnsArticlePage() {
+        // Given
+        Pageable pageable = Pageable.ofSize(20);
+        given(articleRepository.findAll(pageable)).willReturn(Page.empty());
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticles(null, null, pageable);
+
+        // Then
+        assertThat(articles).isEmpty();
+        then(articleRepository).should().findAll(pageable);
+    }
+
+    @DisplayName("검색어와 함께 게시글을 검색하면, 게시판 페이지를 반환한다.")
+    @Test
+    void givenSearchParameters_whenSearchingArticles_thenReturnsArticlePage() {
+        // Given
+        SearchType searchType = SearchType.TITLE;
+        String searchKeyword = "title";
+        Pageable pageable = Pageable.ofSize(20);
+        given(articleRepository.findByTitleContaining(searchKeyword, pageable)).willReturn(Page.empty());
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticles(searchType, searchKeyword, pageable);
+
+        // Then
+        assertThat(articles).isEmpty();
+        then(articleRepository).should().findByTitleContaining(searchKeyword, pageable);
+    }
+
+    @DisplayName("게시글 ID로 조회하면, 댓글 달긴 게시글을 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingArticleWithComments_thenReturnsArticleWithComments() {
+        // Given
+        Long articleId = 1L;
+        Article article = createArticle();
+        given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+
+        // When
+        ArticleWithCommentsDto dto = sut.getArticleWithComments(articleId);
+
+        // Then
+        assertThat(dto)
+                .hasFieldOrPropertyWithValue("title", article.getTitle())
+                .hasFieldOrPropertyWithValue("content", article.getContent());
+        then(articleRepository).should().findById(articleId);
+    }
+
+    @DisplayName("게시글이 없으면, 예외를 던진다.")
+    @Test
+    void givenNonexistentArticleId_whenSearchingArticle_thenThrowsException() {
+        // Given
+        Long articleId = 0L;
+        given(articleRepository.findById(articleId)).willReturn(Optional.empty());
+
+        // When
+        Throwable t = catchThrowable(() -> sut.getArticleWithComments(articleId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("게시글 조회를 실패했습니다. 게시글을 찾을 수 없습니다. - articleId : " + articleId);
+        then(articleRepository).should().findById(articleId);
+    }
+
+    @DisplayName("게시글 정보를 입력하면, 게시글을 생성한다.")
+    @Test
+    void givenArticleInfo_whenSavingArticle_thenSavesArticle() {
+        // Given
+        ArticleDto dto = createArticleDto();
+        given(userRepository.getReferenceById(dto.getUserDto().getId())).willReturn(createUser());
+        given(articleRepository.save(any(Article.class))).willReturn(createArticle());
+
+        // When
+        sut.saveArticle(dto);
+
+        // Then
+        then(userRepository).should().getReferenceById(dto.getUserDto().getId());
+        then(articleRepository).should().save(any(Article.class));
+    }
+
+    @DisplayName("게시글의 수정 정보를 입력하면, 게시글을 수정한다.")
+    @Test
+    void givenArticleIdAndModifiedInfo_whenUpdatingArticle_thenUpdatesArticle() {
+        // Given
+        Article article = createArticle();
+        ArticleDto dto = createArticleDto("새 타이틀", "새 내용", createUserDto());
+        given(articleRepository.getReferenceById(article.getId())).willReturn(article);
+        given(userRepository.getReferenceById(dto.getUserDto().getId())).willReturn(dto.getUserDto().toEntity());
+
+        // When
+        sut.updateArticle(article.getId(), dto);
+
+        // Then
+        assertThat(article)
+                .hasFieldOrPropertyWithValue("title", dto.getTitle())
+                .hasFieldOrPropertyWithValue("content", dto.getContent());
+        then(articleRepository).should().getReferenceById(dto.getId());
+        then(userRepository).should().getReferenceById(dto.getUserDto().getId());
+    }
+
+    @DisplayName("없는 게시글의 수정 정보를 입력하면, 경고 로그를 찍고 아무 것도 하지 않는다.")
+    @Test
+    void givenNonexistentArticleInfo_whenUpdatingArticle_thenLogsWarningAndDoesNothing() {
+        // Given
+        ArticleDto dto = createArticleDto("새 타이틀", "새 내용", UserDto.of(1L));
+        given(articleRepository.getReferenceById(dto.getId())).willThrow(EntityNotFoundException.class);
+
+        // When
+        sut.updateArticle(dto.getId(), dto);
+
+        // Then
+        then(articleRepository).should().getReferenceById(dto.getId());
+    }
+
+    @DisplayName("게시글의 ID 와 유저 ID 를 입력하면, 게시글을 삭제한다")
+    @Test
+    void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
+        // Given
+        Long articleId = 1L;
+        Long userId = 1L;
+        willDoNothing().given(articleRepository).deleteByIdAndUser_Id(articleId, userId);
+
+        // When
+        sut.deleteArticle(1L, 1L);
+
+        // Then
+        then(articleRepository).should().deleteByIdAndUser_Id(articleId, userId);
+    }
+
+    @DisplayName("게시글 수를 조회하면, 게시글 수를 반환한다")
+    @Test
+    void givenNothing_whenCountingArticles_thenReturnsArticleCount() {
+        // Given
+        long expected = 0L;
+        given(articleRepository.count()).willReturn(expected);
+
+        // When
+        long actual = sut.getArticleCount();
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+        then(articleRepository).should().count();
+    }
+
+    private User createUser() {
+        return User.of(1L);
+    }
+
+    private Article createArticle() {
+        Article article = Article.of(
+                "title",
+                "content",
+                createUser()
+        );
+        ReflectionTestUtils.setField(article, "id", 1L);
+
+        return article;
+    }
+
+    private UserDto createUserDto() {
+        return UserDto.of(1L);
+    }
+
+    private ArticleDto createArticleDto() {
+        return createArticleDto("title", "content", createUserDto());
+    }
+
+    private ArticleDto createArticleDto(String title, String content, UserDto userDto) {
+        return ArticleDto.of(1L, title, content, userDto, LocalDateTime.now());
+    }
+}

--- a/src/test/java/kr/kw/matcher/module/article/service/PaginationServiceTest.java
+++ b/src/test/java/kr/kw/matcher/module/article/service/PaginationServiceTest.java
@@ -1,0 +1,65 @@
+package kr.kw.matcher.module.article.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("비즈니스 로직 - 페이지네이션")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = PaginationService.class)
+class PaginationServiceTest {
+    private final PaginationService sut;
+
+    public PaginationServiceTest(@Autowired PaginationService paginationService) {
+        this.sut = paginationService;
+    }
+
+    @DisplayName("현재 페이지 번호와 총 페이지 수를 주면, 페이징 바 리스트를 만들어준다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] 현재 페이지: {0}, 총 페이지: {1} => {2}")
+    void givenCurrentPageNumberAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers(int currentPageNumber, int totalPages, List<Integer> expected) {
+        // Given
+
+        // When
+        List<Integer> actual = sut.getPaginationBarNumbers(currentPageNumber, totalPages);
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> givenCurrentPageNumberAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers() {
+        return Stream.of(
+                arguments(0, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(1, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(2, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(3, 13, List.of(1, 2, 3, 4, 5)),
+                arguments(4, 13, List.of(2, 3, 4, 5, 6)),
+                arguments(5, 13, List.of(3, 4, 5, 6, 7)),
+                arguments(6, 13, List.of(4, 5, 6, 7, 8)),
+                arguments(10, 13, List.of(8, 9, 10, 11, 12)),
+                arguments(11, 13, List.of(9, 10, 11, 12)),
+                arguments(12, 13, List.of(10, 11, 12))
+        );
+    }
+
+    @DisplayName("현재 설정되어 있는 페이지네이션 바의 길이를 알려준다.")
+    @Test
+    void givenNothing_whenCalling_thenReturnsCurrentBarLength() {
+        // Given
+
+        // When
+        int barLength = sut.currentBarLength();
+
+        // Then
+        assertThat(barLength).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
게시판 기능을 위한 서비스단을 작성하였다.
동일성 검사를 위해 엔티티에 `equals & hashCode` 를 추가하였다.
사용자가 게시글 제목, 내용 검색을 효율적으로 할 수 있도록 `querydsl` 를 활용했다.