### PR TITLE
Update Controller layer & Service layer for article

### DIFF
--- a/src/main/java/kr/kw/matcher/module/article/controller/ArticleController.java
+++ b/src/main/java/kr/kw/matcher/module/article/controller/ArticleController.java
@@ -56,7 +56,7 @@ public class ArticleController {
     }
 
     // 게시글 입력
-    @PostMapping("/write")
+    @PostMapping
     public void postNewArticle(
             @Valid @RequestBody ArticleRequest articleRequest,
             @AuthenticationPrincipal Member member
@@ -66,7 +66,7 @@ public class ArticleController {
     }
 
     // 게시글 업데이트
-    @PatchMapping("/{articleId}/write")
+    @PatchMapping("/{articleId}")
     public void updateArticle(
             @PathVariable Long articleId,
             @Valid @RequestBody ArticleRequest articleRequest,

--- a/src/main/java/kr/kw/matcher/module/article/controller/ArticleController.java
+++ b/src/main/java/kr/kw/matcher/module/article/controller/ArticleController.java
@@ -17,6 +17,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -57,7 +58,7 @@ public class ArticleController {
     // 게시글 입력
     @PostMapping("/write")
     public void postNewArticle(
-            ArticleRequest articleRequest,
+            @Valid @RequestBody ArticleRequest articleRequest,
             @AuthenticationPrincipal Member member
     ) {
         String nickname = articleService.getUserNickname(member.getId());
@@ -68,7 +69,7 @@ public class ArticleController {
     @PatchMapping("/{articleId}/write")
     public void updateArticle(
             @PathVariable Long articleId,
-            ArticleRequest articleRequest,
+            @Valid @RequestBody ArticleRequest articleRequest,
             @AuthenticationPrincipal Member member
     ) {
         String nickname = articleService.getUserNickname(member.getId());

--- a/src/main/java/kr/kw/matcher/module/article/controller/ArticleController.java
+++ b/src/main/java/kr/kw/matcher/module/article/controller/ArticleController.java
@@ -65,7 +65,7 @@ public class ArticleController {
     }
 
     // 게시글 업데이트
-    @PostMapping("/{articleId}/write")
+    @PatchMapping("/{articleId}/write")
     public void updateArticle(
             @PathVariable Long articleId,
             ArticleRequest articleRequest,
@@ -76,7 +76,7 @@ public class ArticleController {
     }
 
     // 게시글 삭제
-    @PostMapping ("/{articleId}/delete")
+    @DeleteMapping("/{articleId}")
     public void deleteArticle(
             @PathVariable Long articleId,
             @AuthenticationPrincipal Member member

--- a/src/main/java/kr/kw/matcher/module/article/service/ArticleCommentService.java
+++ b/src/main/java/kr/kw/matcher/module/article/service/ArticleCommentService.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
피드백을 바탕으로 게시글 서비스와 컨트롤러 단을 수정했다.

게시글 컨트롤러 단
* Rest API 규격으로 수정
* Request 객체에 `@Valid`, `@RequestBody` 어노테이션 추가

게시글 서비스 단
* 데이터 존재 체크를 하는 부분에 `getReference` 대신 `findBy` 사용

이에 영향을 받는 테스트 코드도 수정했다. 모든 테스트가 정상 작동하는 것을 확인했다.